### PR TITLE
Incident index and other stories

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -4,6 +4,8 @@
 
 /* This file is for your main application CSS */
 
+/* Incident view */
+
 .incident-counter {
   display: flex;
   flex-direction: column;
@@ -48,4 +50,41 @@
 
 .reset-button:hover {
   background-color: #c0392b;
+}
+
+/* Index */
+
+.incident-index {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.incident-index h1 {
+  font-size: 24px;
+  margin-bottom: 20px;
+}
+
+.incident-index ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+.incident-item {
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  padding: 10px;
+  margin-bottom: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.incident-name {
+  font-weight: bold;
+}
+
+.incident-date {
+  font-size: 14px;
+  color: #666;
 }

--- a/lib/sector7g/days_since.ex
+++ b/lib/sector7g/days_since.ex
@@ -21,13 +21,12 @@ defmodule Sector7g.DaysSince do
     GenServer.cast(__MODULE__, {:new, incident_name})
   end
 
-  def days_since() do
-    # TODO not sure we need this anymore
-    GenServer.call(__MODULE__, :days_since)
-  end
-
   def days_since(incident_name) do
     GenServer.call(__MODULE__, {:days_since, incident_name})
+  end
+
+  def get_incident(incident_name) do
+    GenServer.call(__MODULE__, {:get, incident_name})
   end
 
   # =============================
@@ -58,5 +57,10 @@ defmodule Sector7g.DaysSince do
   def handle_call({:days_since, incident_name}, _from, state) do
     incident = Incident.get_incident_by_name(incident_name)
     {:reply, incident.last_incident |> Incident.calculate_days_since_timestamp(), state}
+  end
+
+  @impl true
+  def handle_call({:get, incident_name}, _from, state) do
+    {:reply, Incident.get_incident_by_name(incident_name), state}
   end
 end

--- a/lib/sector7g/days_since.ex
+++ b/lib/sector7g/days_since.ex
@@ -11,14 +11,8 @@ defmodule Sector7g.DaysSince do
   require Logger
 
   def start_link([]) do
-    # TODO spawn with custom incident name
     GenServer.start_link(__MODULE__, "last_incident", name: __MODULE__)
   end
-
-  def reset_counter() do
-    GenServer.cast(__MODULE__, :reset)
-  end
-
   def reset_counter(incident_name) do
     GenServer.cast(__MODULE__, {:reset, incident_name})
   end
@@ -28,6 +22,7 @@ defmodule Sector7g.DaysSince do
   end
 
   def days_since() do
+    # TODO not sure we need this anymore
     GenServer.call(__MODULE__, :days_since)
   end
 
@@ -42,59 +37,26 @@ defmodule Sector7g.DaysSince do
   @impl true
   def init(incident) do
     {:ok, init_date, 0} = DateTime.from_iso8601("2019-07-23T01:27:00+00:00")
-    case Incident.new_incident_changeset(incident, init_date) |> Repo.insert(on_conflict: :nothing) do
-      {:error, failed_insert} -> {:error, failed_insert.errors}
-      {:ok, _successful_insert} -> {:ok, %{incident: incident, last_incident: init_date}}
-    end
-  end
-
-  @impl true
-  def handle_cast(:reset, state) do
-    # TODO conjure useless metrics for this
-    {:noreply, state |> Map.put(:last_incident, DateTime.utc_now())}
+    Incident.insert_new_type_of_incident(incident, init_date)
   end
 
   @impl true
   def handle_cast({:reset, incident_name}, state) do
-    # TODO conjure useless metrics for this
-    case Repo.get_by(Incident, name: incident_name) do
-      nil -> {:error, :not_found} # TODO better error
-      record ->
-        record
-        |> Incident.changeset(%{incident_date: DateTime.utc_now()})
-        |> Repo.update()
-    end
-    # TODO move this to the case handling I guess
-    {:noreply, state |> Map.put(:last_incident, DateTime.utc_now())}
-  end
-
-
-  @impl true
-  def handle_call({:new, incident_name}, state) do
-    case Incident.new_incident_changeset(incident_name, DateTime.utc_now()) |> Repo.insert() do
-      {:ok, _new_incident} -> {:noreply, state} # TODO update state here
-      {:error, changeset_error} -> {:error, changeset_error.errors} # TODO differentiate b/w errors
-    end
+    Incident.reset_incident_counter_by_name(incident_name)
     {:noreply, state}
   end
 
   @impl true
-  def handle_call(:days_since, _from, state) do
-    {:reply, calculate_days_since(state.last_incident), state}
+  def handle_cast({:new, incident_name}, state) do
+    case Incident.new_incident_changeset(incident_name, DateTime.utc_now()) |> Repo.insert() do
+      {:ok, _new_incident} -> {:noreply, state} # TODO update state here
+      {:error, changeset_error} -> {:error, changeset_error.errors} # TODO differentiate b/w errors
+    end
   end
 
   @impl true
-  def handle_call({:days_since, _incident_name}, _from, state) do
-    # TODO implement me
-    {:reply, calculate_days_since(state.last_incident), state}
+  def handle_call({:days_since, incident_name}, _from, state) do
+    incident = Incident.get_incident_by_name(incident_name)
+    {:reply, incident.last_incident |> Incident.calculate_days_since_timestamp(), state}
   end
-
-  # =============================
-  # functions
-  # =============================
-  def calculate_days_since(utc_timestamp) do
-    DateTime.utc_now()
-    |> DateTime.diff(utc_timestamp, :day)
-  end
-
 end

--- a/lib/sector7g/incident.ex
+++ b/lib/sector7g/incident.ex
@@ -7,7 +7,7 @@ defmodule Sector7g.Incident do
   @topic "incidents"
 
   schema "incidents" do
-    field :last_incident, :date
+    field :last_incident, :utc_datetime
     field :name, :string
     # TODO add field for full_name or something more long form
 
@@ -50,6 +50,11 @@ defmodule Sector7g.Incident do
       nil -> {:error, :not_found} # TODO better error
       record -> {:ok, record}
       end
+  end
+
+  def calculate_days_since(utc_timestamp) do
+    DateTime.utc_now()
+    |> DateTime.diff(utc_timestamp, :day)
   end
 
   def reset_incident_counter(name) do

--- a/lib/sector7g/incident.ex
+++ b/lib/sector7g/incident.ex
@@ -1,11 +1,15 @@
 defmodule Sector7g.Incident do
+  require Logger
   alias Sector7g.Incident
   use Ecto.Schema
   import Ecto.Changeset
 
+  @topic "incidents"
+
   schema "incidents" do
     field :last_incident, :date
     field :name, :string
+    # TODO add field for full_name or something more long form
 
     timestamps(type: :utc_datetime)
   end
@@ -18,9 +22,50 @@ defmodule Sector7g.Incident do
     |> unique_constraint(:name)
   end
 
+  # =============================
+  # doobydoobydoo
+  # =============================
+
   # TODO make it default in a more ecto way I guess
   def new_incident_changeset(name, date \\ DateTime.utc_now()) do
     %Incident{}
     |> changeset(%{name: name, last_incident: date})
+  end
+
+  # TODO add rm functionality
+  def insert_new_type_of_incident(name, date \\ DateTime.utc_now()) do
+    case %Incident{}
+    |> changeset(%{name: name, last_incident: date})
+    |> Sector7g.Repo.insert(on_conflict: :nothing) # TODO fix that it still pubs to the topic on conflict
+    do
+      {:ok, _successful_insert} ->
+        Phoenix.PubSub.broadcast(Sector7g.PubSub, @topic, {:incident_updated})
+        {:ok, %{incident: name, last_incident: date}}
+      {:error, failed_insert} -> {:error, failed_insert.errors}
+    end
+  end
+
+  def get_incident_by_name(name) do
+    case Sector7g.Repo.get_by!(Incident, name: name) do
+      nil -> {:error, :not_found} # TODO better error
+      record -> {:ok, record}
+      end
+  end
+
+  def reset_incident_counter(name) do
+    # TODO we probably should not be doing case within a case
+    case Sector7g.Repo.get_by(Incident, name: name) do
+      nil -> {:error, :not_found} # TODO better error
+      record ->
+        case record
+        |> Incident.changeset(%{incident_date: DateTime.utc_now()})
+        |> Sector7g.Repo.update()
+        do
+          {:ok, reset_counter} ->
+            # TODO look into why this does not seem to propogate to the frontend
+            Phoenix.PubSub.broadcast(Sector7g.PubSub, @topic, {:incident_updated})
+            {:ok, reset_counter}
+        end
+    end
   end
 end

--- a/lib/sector7g_web/live/days_since_live.ex
+++ b/lib/sector7g_web/live/days_since_live.ex
@@ -1,15 +1,17 @@
-# lib/my_app_web/live/incident_counter_live.ex
 defmodule Sector7gWeb.DaysSinceLive do
+  alias Sector7g.Incident
   use Sector7gWeb, :live_view
+  require Logger
 
-  def mount(_params, _session, socket) do
-    days = Sector7g.DaysSince.days_since()
-    {:ok, assign(socket, days: days)}
+  def mount(%{"name" => name}, _session, socket) do
+    record = Incident.get_incident_by_name(name)
+    {:ok, assign(socket, incident: record, days: Incident.calculate_days_since_timestamp(record.last_incident))}
   end
 
   def handle_event("reset", _params, socket) do
-    Sector7g.DaysSince.reset_counter()
-    days = Sector7g.DaysSince.days_since()
-    {:noreply, assign(socket, days: days)}
+    # TODO this should maybe be more clever
+    %{assigns: %{incident: incident}} = socket
+    Sector7g.DaysSince.reset_counter(incident.name)
+    {:noreply, assign(socket, days: 0)}
   end
 end

--- a/lib/sector7g_web/live/days_since_live.html.heex
+++ b/lib/sector7g_web/live/days_since_live.html.heex
@@ -1,7 +1,7 @@
 <div class="incident-counter">
   <h1 class="counter">
+    <span class="label">Days Since <%= @incident.name %></span>
     <span class="days"><%= @days %></span>
-    <span class="label">Days Since Last Incident</span>
   </h1>
   <button class="reset-button" phx-click="reset">RESET</button>
 </div>

--- a/lib/sector7g_web/live/incident_index_live.ex
+++ b/lib/sector7g_web/live/incident_index_live.ex
@@ -1,0 +1,24 @@
+defmodule Sector7gWeb.IncidentIndexLive do
+  use Sector7gWeb, :live_view
+  alias Sector7g.Incident
+
+  @topic "incidents"
+
+  def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Sector7g.PubSub, @topic)
+    end
+
+    incidents = list_incidents()
+    {:ok, assign(socket, incidents: incidents)}
+  end
+
+  def handle_info({:incident_updated}, socket) do
+    incidents = list_incidents()
+    {:noreply, assign(socket, incidents: incidents)}
+  end
+
+  defp list_incidents do
+    Sector7g.Repo.all(Incident)
+  end
+end

--- a/lib/sector7g_web/live/incident_index_live.html.heex
+++ b/lib/sector7g_web/live/incident_index_live.html.heex
@@ -1,0 +1,11 @@
+<div class="incident-index">
+  <h1>Registered Incidents</h1>
+  <ul>
+    <%= for incident <- @incidents do %>
+      <li class="incident-item">
+        <span class="incident-name"><%= incident.name %></span>
+        <span class="incident-date">Last incident: <%= Calendar.strftime(incident.last_incident, "%Y-%m-%d") %></span>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/lib/sector7g_web/router.ex
+++ b/lib/sector7g_web/router.ex
@@ -1,5 +1,6 @@
 defmodule Sector7gWeb.Router do
   use Sector7gWeb, :router
+  import Phoenix.LiveView.Router
 
   pipeline :browser do
     plug :accepts, ["html"]
@@ -17,7 +18,8 @@ defmodule Sector7gWeb.Router do
   scope "/", Sector7gWeb do
     pipe_through :browser
 
-    live "/", DaysSinceLive, :home
+    live "/", IncidentIndexLive, :home
+    live "/:name", DaysSinceLive
   end
 
   # Other scopes may use custom stacks.

--- a/priv/repo/migrations/20240910072545_create_incidents.exs
+++ b/priv/repo/migrations/20240910072545_create_incidents.exs
@@ -3,7 +3,7 @@ defmodule Sector7g.Repo.Migrations.CreateIncidents do
 
   def change do
     create table(:incidents) do
-      add :last_incident, :date
+      add :last_incident, :utc_datetime
       add :name, :string
 
       timestamps(type: :utc_datetime)


### PR DESCRIPTION
- Support for multiple incidents now
  - Use of DB from last PR
  - Index page at root
    - Smol amount of CSS for that 
    - Can not click to navigate yet, I want to add readable names and such and will do that work in that PR
    - No way to add more incidents in the UI yet, needs to be done in the backend lol
- If you enter a subpath which does not exist as a incident name in the DB it will 404 on you. If running in dev mode it will however give you the Phoenix error stack trace.
- Moved DB logic entirely to `incidents.ex`
  - I want all interactions with the DB to be exposed from there
  - This might actually be super bad practice but I'd rather figure that out later to learn from it then than nerd out about it right now who cares   