### PR TITLE
Build and push to ghcr on GitHub Release

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,0 +1,45 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Elixir Build and push
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  container-build-and-push:
+
+    name: Build container and push
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Elixir
+      uses: erlef/setup-beam@61e01a43a562a89bfc54c7f9a378ff67b03e4a21 # v1.16.0
+      with:
+        elixir-version: '1.15.2' # [Required] Define the Elixir version
+        otp-version: '26.0'      # [Required] Define the Erlang/OTP version
+    - name: Restore dependencies cache
+      uses: actions/cache@v3
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-mix-
+    - name: Install dependencies
+      run: mix deps.get
+    - name: Run tests
+      run: mix test
+
+    - name: Build and publish a Docker image for ${{ github.repository }}
+      uses: macbre/push-to-ghcr@master
+      with:
+        image_name: ${{ github.repository }}  # it will be lowercased internally
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -21,6 +21,9 @@ jobs:
 
     name: Build container and push
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,10 +6,7 @@
 name: Elixir Build and push
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  # I hate latest and releases should be stable
   release:
     types: [ published ]
 

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,6 +10,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  release:
+    types: [ published ]
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR simply adds a GitHub action, which uses the default functionality from here https://github.com/macbre/push-to-ghcr

It 
- Pulls 
- Builds
- Runs tests (There are none! :tada:)
- Builds container
- Tags container with triggered release
- Pushes docker container to this repos container package